### PR TITLE
Change "Github" to "GitHub" for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can follow our progress at our [JIRA](https://simp-project.atlassian.net) pa
 # Where's the code?!
 
 For those out there that just want the goods, the actual code for the SIMP
-project is hosted under the [SIMP Github Organization](https://github.com/simp).
+project is hosted under the [SIMP GitHub Organization](https://github.com/simp).
 
 ## Description
 


### PR DESCRIPTION
I noticed that this is the only place where GitHub is not spelled correctly in the entire repository, so I changed it to improve the consistency.
