### PR TITLE
(SIMP-1145) Fix confusing backlinks in primary README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 .. contents:: Table of Contents
    :depth: 3
+   :backlinks: none
 
 System Integrity Management Platform (SIMP)
 ===========================================


### PR DESCRIPTION
This disables the table of contents backlinks.  Backlinks are links from
the header text back to the table of contents.

SIMP-1145 #close
